### PR TITLE
Write a nix dev shell compatible with bevy system libraries dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "nix"
+    ]
+}

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,26 @@
         "type": "github"
       }
     },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764011051,
+        "narHash": "sha256-M7SZyPZiqZUR/EiiBJnmyUbOi5oE/03tCeFrTiUZchI=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "17ed8d9744ebe70424659b0ef74ad6d41fc87071",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1762111121,
@@ -40,7 +60,29 @@
     "root": {
       "inputs": {
         "blueprint": "blueprint",
-        "nixpkgs": "nixpkgs"
+        "devshell": "devshell",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764816035,
+        "narHash": "sha256-F0IQSmSj4t2ThkbWZooAhkCTO+YpZSd2Pqiv2uoYEHo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "74d9abb7c5c030469f90d97a67d127cc5d76c238",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,22 @@
   # Add all your dependencies here
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
     blueprint.url = "github:numtide/blueprint";
     blueprint.inputs.nixpkgs.follows = "nixpkgs";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   # Load the blueprint
-  outputs = inputs: inputs.blueprint { inherit inputs; };
+  outputs = inputs @ {rust-overlay, ...}:
+    inputs.blueprint {
+      inherit inputs;
+      nixpkgs.overlays = [
+        rust-overlay.overlays.default
+      ];
+    };
 }

--- a/formatter.nix
+++ b/formatter.nix
@@ -2,8 +2,7 @@
   pname,
   pkgs,
   flake,
-}:
-let
+}: let
   formatter = pkgs.alejandra;
 in
-formatter
+  formatter

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
+# Documentation: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
 channel = "nightly"
+components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
Add nix packages: 
- rust-overlay
- devshell 
I then modified the nix development shell to an implementation inspired by the outdated flake example on the bevy github repo.
It took a little trial and error but now includes all the necessary libraries required to build devy and devy's dependencies.

Closes #4