### PR TITLE
Reduce nix support from linux, macos, x86, and arm to just "x86_64-linux"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,11 @@
     inputs.blueprint {
       inherit inputs;
       prefix = "nix/";
+      ### the systems field controls which system architectures this flake will try to support
+      systems = [
+        "x86_64-linux"
+        # TODO: Consider adding "aarch64-darwin" for Arm-chip MacOS support
+      ];
       nixpkgs.overlays = [
         rust-overlay.overlays.default
       ];


### PR DESCRIPTION
I think it makes more sense to explicitly list the systems we are using for development and then we can widen them later on if and when we add support for other systems.  The only concern might be that this opens up an oportunity for tech debt. Since this reduces the system count to 1, future nix code may be written that doesn't dynamically handle multiple systems and just hardcodes the one.